### PR TITLE
Ignore context on __len__()

### DIFF
--- a/rdflib_hdt/hdt_store.py
+++ b/rdflib_hdt/hdt_store.py
@@ -36,7 +36,7 @@ class HDTStore(Store):
         """Return True if the HDT store ignores Unicode errors, False otherwise."""
         return self._hdt_document.is_safe()
 
-    def __len__(self) -> int:
+    def __len__(self, context) -> int:
         """The number of RDF triples in the HDT store."""
         return self._hdt_document.total_triples
 


### PR DESCRIPTION
On newer versions of rdflib the __len__() function of a Store can be called with additional parameters, this is a hotfix as the Store was breaking otherwise.

A proper solution to take "context" into account may be needed...

https://github.com/RDFLib/rdflib/blob/b0392f0a50db3b49cf6ec93bfbe0672a0fba16d6/rdflib/graph.py#L673 